### PR TITLE
fix for stalled commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/jython_kernel.py
+++ b/jython_kernel.py
@@ -155,8 +155,7 @@ class JythonKernel(Kernel):
         for line in code.splitlines():
             self._child.sendline(line)
             now_prompt=self._child.expect_exact([u">>> ",u"... "])
-            if len(self._child.before.splitlines())>1:    out+='\n'.join(self._child.before.splitlines()[1:])+'\n'
-            # now_prompt=self._child.expect_exact([u">>> ",u"... "])
+            if len(self._child.before.splitlines())>1:    out+='\n'.join(self._child.before.decode('UTF-8').splitlines()[1:])+'\n'
         return out
 
 if __name__ == '__main__':

--- a/jython_kernel.py
+++ b/jython_kernel.py
@@ -1,5 +1,5 @@
 from ipykernel.kernelbase import Kernel
-from IPython.utils.path import locate_profile
+from IPython.paths import locate_profile
 from pexpect import replwrap,EOF,spawn
 import signal
 import re
@@ -42,7 +42,6 @@ class JythonKernel(Kernel):
                raise Exception("JYTHON_HOME not set or jython not found") 
             self._child  = spawn(self._executable,timeout = None)
             self._child.waitnoecho(True)
-            self._child.expect(u">>> ")
             self._child.expect(u">>> ")
             self._child.setwinsize(600,400)
         finally:
@@ -157,7 +156,7 @@ class JythonKernel(Kernel):
             self._child.sendline(line)
             now_prompt=self._child.expect_exact([u">>> ",u"... "])
             if len(self._child.before.splitlines())>1:    out+='\n'.join(self._child.before.splitlines()[1:])+'\n'
-            now_prompt=self._child.expect_exact([u">>> ",u"... "])
+            # now_prompt=self._child.expect_exact([u">>> ",u"... "])
         return out
 
 if __name__ == '__main__':


### PR DESCRIPTION
the response from Jython might have changed from double >>> lines to a single one, but the primary fix here was eliminating extra "expect" lines. This addresses the problem in https://github.com/suvarchal/IJython/issues/7 and https://github.com/suvarchal/IJython/issues/10

An additional issue was converting the return into a string from a byte array.

Also, I added a .gitignore file with the standard Python ignore.